### PR TITLE
fix: stop dependabot automerge from self-blocking via cancelled check runs

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,8 +1,12 @@
 name: Automerge Dependabot
 
 on:
-  pull_request_target:
-    types: [opened, synchronize, labeled, ready_for_review]
+  # PRs are never eligible immediately anyway (minimum-age-of-pr gate below), and
+  # triggering on every PR event caused overlapping runs that got cancelled by the
+  # concurrency group below. Cancelled runs leave a "cancelled" check-run conclusion
+  # on the commit, which the automerge action itself then reads back as a failing
+  # check on every subsequent evaluation - permanently blocking that PR from ever
+  # auto-merging. Rely on the daily schedule (+ manual dispatch) instead.
   schedule:
     - cron: "0 7 * * *" # daily at 07:00 UTC
   workflow_dispatch:
@@ -14,8 +18,8 @@ permissions:
   statuses: read
 
 concurrency:
-  group: automerge-dependabot-${{ github.event.pull_request.number || 'schedule' }}
-  cancel-in-progress: true
+  group: automerge-dependabot
+  cancel-in-progress: false
 
 jobs:
   automerge:


### PR DESCRIPTION
## Why automerge wasn't working

Investigated the `Automerge Dependabot` workflow and confirmed the root cause via debug logging and the GitHub Checks API — it's a self-inflicted bug, not a misconfiguration of filters.

### Root cause

1. The workflow triggered on every `pull_request_target` event: `opened, synchronize, labeled, ready_for_review`.
2. GitHub often delivers several of these near-simultaneously for a single dependabot PR, spawning multiple runs for the same PR.
3. The `concurrency` group (`automerge-dependabot-<pr-number>`, `cancel-in-progress: true`) cancels the older run(s) when a new one starts.
4. Each **cancelled** run still creates a completed GitHub check run named `automerge` with `conclusion: cancelled`, permanently attached to that commit SHA (visible via `GET /commits/{sha}/check-runs`).
5. The `navikt/automerge-dependabot` action evaluates PR eligibility by calling `checks.listForRef` on the head SHA and treats **any** check run with conclusion `failure | cancelled | timed_out | action_required | stale` as a blocking failure — including its own leftover cancelled run.
6. Result: the PR is flagged as "has failing checks" forever, even though the real CI (`build-and-lint`) and the successful `automerge` run both passed. Verified with `ACTIONS_STEP_DEBUG` logs, e.g.:
   ```
   PR #1387 mergeable state determined: true (attempt 1)
   PR #1387 has failing checks
   ```
   ...while `gh pr checks 1387` showed both `automerge` and `build-and-lint` passing. Confirmed the same stray `cancelled` "automerge" check run exists on several other manually-merged PRs (#1384, #1387–#1391).

Additionally, the `pull_request_target` trigger never actually merges anything useful on its own: it fires the instant a PR is opened, long before `minimum-age-of-pr: 0.25` (~6h) is satisfied, so it always reports 0 eligible PRs at that point — its only real effect was contributing to the race/cancellation described above.

### Fix

- Drop the `pull_request_target` trigger entirely; rely on the daily `schedule` (07:00 UTC) + `workflow_dispatch` for manual runs. This removes the race condition that produced stray cancelled check runs.
- Simplify the `concurrency` group to a single non-PR-specific group and set `cancel-in-progress: false`, so scheduled/manual runs queue instead of cancelling each other.

### Follow-up (not in this PR)

The underlying bug in `navikt/automerge-dependabot`'s `evaluateChecks()` — treating *any* historical check run (rather than just the latest per name) as blocking — should also be fixed upstream so this class of issue can't recur from other cancelled workflows. Happy to file that upstream if useful.

### Verification

- Reproduced the issue: triggered the workflow manually with debug logging and confirmed `"has failing checks"` for PRs #1378, #1387–#1391 despite all real checks passing.
- Confirmed via GitHub Checks API that each affected PR's head commit has a stray `automerge` check run with `conclusion: cancelled` alongside the successful one.
